### PR TITLE
Remove procedure and use UUID in exam manager

### DIFF
--- a/.github/workflows/static-tests.yml
+++ b/.github/workflows/static-tests.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache poetry install
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.local
           key: poetry
@@ -53,7 +53,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Cache poetry dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cached-poetry-dependencies
         with:
           path: .venv

--- a/services/exam-manager/app/api/dal.py
+++ b/services/exam-manager/app/api/dal.py
@@ -4,6 +4,7 @@
 """Data access layer."""
 
 from pprint import pprint
+from uuid import UUID
 
 from sqlalchemy.engine import Result
 from sqlalchemy.future import select
@@ -35,7 +36,7 @@ async def exam_add(payload: BaseExam) -> Exam:
     return new_exam
 
 
-async def exam_get(exam_id: int) -> (Exam | None):
+async def exam_get(exam_id: UUID) -> (Exam | None):
     """Get exam by id.
 
     Parameters
@@ -52,7 +53,7 @@ async def exam_get(exam_id: int) -> (Exam | None):
     return exam
 
 
-async def exam_get_all(patient_id: int) -> list[Exam]:
+async def exam_get_all(patient_id: UUID) -> list[Exam]:
     """Get a list of all exams assigned to a certain patient.
 
     Parameters
@@ -70,7 +71,7 @@ async def exam_get_all(patient_id: int) -> list[Exam]:
     return exams
 
 
-async def exam_delete(exam_id: int) -> bool:
+async def exam_delete(exam_id: UUID) -> bool:
     """Delete exam by id.
 
     Parameters
@@ -90,7 +91,7 @@ async def exam_delete(exam_id: int) -> bool:
         return False
 
 
-async def update_exam(exam_id: int, payload: BaseExam) -> (Exam | None):
+async def update_exam(exam_id: UUID, payload: BaseExam) -> (Exam | None):
     """Update existing exam entry.
 
     Parameters
@@ -137,7 +138,7 @@ async def add_job(payload: BaseJob) -> Job:
     return new_job
 
 
-async def get_job(job_id: int) -> (Job | None):
+async def get_job(job_id: UUID) -> (Job | None):
     """Get job by id.
 
     Parameters
@@ -154,7 +155,7 @@ async def get_job(job_id: int) -> (Job | None):
     return job
 
 
-async def get_all_jobs(exam_id: int) -> list[Job]:
+async def get_all_jobs(exam_id: UUID) -> list[Job]:
     """Get a list of all jobs assigned to a certain exam.
 
     Parameters
@@ -172,7 +173,7 @@ async def get_all_jobs(exam_id: int) -> list[Job]:
     return jobs
 
 
-async def delete_job(job_id: int) -> bool:
+async def delete_job(job_id: UUID) -> bool:
     """Delete a job by ID.
 
     Parameters
@@ -192,7 +193,7 @@ async def delete_job(job_id: int) -> bool:
         return False
 
 
-async def update_job(job_id: int, payload: BaseJob) -> (Job | None):
+async def update_job(job_id: UUID, payload: BaseJob) -> (Job | None):
     """Update existing job in database.
 
     Parameters
@@ -235,7 +236,7 @@ async def add_record(payload: RecordIn) -> Record:
     return new_record
 
 
-async def update_record(record_id: int, payload: dict) -> (Record | None):
+async def update_record(record_id: UUID, payload: dict) -> (Record | None):
     """Update existing record.
 
     Parameters
@@ -259,7 +260,7 @@ async def update_record(record_id: int, payload: dict) -> (Record | None):
         return None
 
 
-async def get_record(record_id: int) -> (Record | None):
+async def get_record(record_id: UUID) -> (Record | None):
     """Get a record from database by id.
 
     Parameters
@@ -276,7 +277,7 @@ async def get_record(record_id: int) -> (Record | None):
     return record
 
 
-async def get_all_records(job_id: int) -> list[Record]:
+async def get_all_records(job_id: UUID) -> list[Record]:
     """Get a list of all records assigned to a certain job.
 
     Parameters
@@ -294,7 +295,7 @@ async def get_all_records(job_id: int) -> list[Record]:
     return records
 
 
-async def delete_record(record_id: int) -> bool:
+async def delete_record(record_id: UUID) -> bool:
     """Delete record by id.
 
     Parameters

--- a/services/exam-manager/app/api/db.py
+++ b/services/exam-manager/app/api/db.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.ext.declarative import DeclarativeMeta, declarative_base
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-# Create base for exam, record and procedure table
+# Create base for exam and job table
 Base: DeclarativeMeta = declarative_base()
 
 if db_uri := os.getenv("DB_URI"):
@@ -37,7 +37,7 @@ class Exam(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
 
     # Relations and references
-    procedures: Mapped[list["Procedure"]] = relationship(lazy="selectin")
+    jobs: Mapped[list["Job"]] = relationship(lazy="selectin")
     patient_id: Mapped[int] = mapped_column(nullable=False)
 
     # Fields
@@ -67,41 +67,6 @@ class Exam(Base):
             setattr(self, key, value)
 
 
-class Procedure(Base):
-    """Procedure ORM model."""
-
-    __tablename__ = "procedure"
-    __table_args__ = {"extend_existing": True}
-
-    # Use uuid here
-    id: Mapped[int] = mapped_column(primary_key=True)
-
-    # Relations and references
-    exam_id: Mapped[int] = mapped_column(ForeignKey("exam.id"))
-    jobs: Mapped[list["Job"]] = relationship(lazy="selectin")
-
-    # Fields
-    name: Mapped[str] = mapped_column(nullable=False)
-    status: Mapped[str] = mapped_column(nullable=False)
-    datetime_created: Mapped[datetime.datetime] = mapped_column(
-        server_default=func.now()  # pylint: disable=not-callable
-    )
-    datetime_updated: Mapped[datetime.datetime] = mapped_column(
-        onupdate=func.now(), nullable=True  # pylint: disable=not-callable
-    )
-
-    def update(self, data: BaseModel) -> None:
-        """Update a procedure entry.
-
-        Parameters
-        ----------
-        data
-            Data to be written
-        """
-        for key, value in data.dict().items():
-            setattr(self, key, value)
-
-
 class Job(Base):
     """Job ORM model."""
 
@@ -112,7 +77,7 @@ class Job(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
 
     # Relations and references
-    procedure_id: Mapped[int] = mapped_column(ForeignKey("procedure.id"))
+    exam_id: Mapped[int] = mapped_column(ForeignKey("exam.id"))
     workflow_id: Mapped[int] = mapped_column(nullable=True)
     device_id: Mapped[str] = mapped_column(nullable=True)
     sequence_id: Mapped[str] = mapped_column(nullable=False)

--- a/services/exam-manager/app/api/exam.py
+++ b/services/exam-manager/app/api/exam.py
@@ -3,6 +3,8 @@
 
 """Exam API endpoints."""
 
+from uuid import UUID
+
 from fastapi import APIRouter, HTTPException
 
 from . import dal
@@ -51,7 +53,7 @@ async def exam_create(payload: BaseExam) -> ExamOut:
 
 
 @router.get("/{exam_id}", response_model=ExamOut, status_code=200, tags=["exams"])
-async def exam_get(exam_id: int) -> ExamOut:
+async def exam_get(exam_id: UUID | str) -> ExamOut:
     """Get exam endpoint.
 
     Parameters
@@ -68,7 +70,8 @@ async def exam_get(exam_id: int) -> ExamOut:
     HTTPException
         404: Not found
     """
-    if not (exam := await dal.exam_get(exam_id)):
+    _id = UUID(exam_id) if not isinstance(exam_id, UUID) else exam_id
+    if not (exam := await dal.exam_get(_id)):
         raise HTTPException(status_code=404, detail="Exam not found")
     return await get_exam_out(data=exam)
 
@@ -93,7 +96,7 @@ async def exam_get_all(patient_id: int) -> list[ExamOut]:
 
 
 @router.delete("/{exam_id}", response_model={}, status_code=204, tags=["exams"])
-async def exam_delete(exam_id: int) -> None:
+async def exam_delete(exam_id: UUID | str) -> None:
     """Delete exam by id.
 
     Parameters
@@ -106,12 +109,13 @@ async def exam_delete(exam_id: int) -> None:
     HTTPException
         404: Not found
     """
-    if not await dal.exam_delete(exam_id):
+    _id = UUID(exam_id) if not isinstance(exam_id, UUID) else exam_id
+    if not await dal.exam_delete(_id):
         raise HTTPException(status_code=404, detail="Exam not found")
 
 
 @router.put("/{exam_id}", response_model=ExamOut, status_code=200, tags=["exams"])
-async def exam_update(exam_id: int, payload: BaseExam) -> ExamOut:
+async def exam_update(exam_id: UUID | str, payload: BaseExam) -> ExamOut:
     """Update exam.
 
     Parameters
@@ -130,7 +134,8 @@ async def exam_update(exam_id: int, payload: BaseExam) -> ExamOut:
     HTTPException
         404: Not found
     """
-    if not (exam := await dal.update_exam(exam_id, payload)):
+    _id = UUID(exam_id) if not isinstance(exam_id, UUID) else exam_id
+    if not (exam := await dal.update_exam(_id, payload)):
         raise HTTPException(status_code=404, detail="Exam not found")
     return await get_exam_out(data=exam)
 
@@ -159,7 +164,7 @@ async def job_create(payload: BaseJob) -> JobOut:
 
 
 @router.get("/job/{job_id}", response_model=JobOut, status_code=200, tags=["jobs"])
-async def job_get(job_id: int) -> JobOut:
+async def job_get(job_id: UUID | str) -> JobOut:
     """Get job endpoint.
 
     Parameters
@@ -176,7 +181,8 @@ async def job_get(job_id: int) -> JobOut:
     HTTPException
         404: Not found
     """
-    if not (job := await dal.get_job(job_id)):
+    _id = UUID(job_id) if not isinstance(job_id, UUID) else job_id
+    if not (job := await dal.get_job(_id)):
         raise HTTPException(status_code=404, detail="Job not found")
     return await get_job_out(data=job)
 
@@ -187,7 +193,7 @@ async def job_get(job_id: int) -> JobOut:
     status_code=200,
     tags=["jobs"],
 )
-async def job_get_all(exam_id: int) -> list[JobOut]:
+async def job_get_all(exam_id: UUID | str) -> list[JobOut]:
     """Get all jobs of a exam endpoint.
 
     Parameters
@@ -199,14 +205,15 @@ async def job_get_all(exam_id: int) -> list[JobOut]:
     -------
         List of job pydantic output model
     """
-    if not (jobs := await dal.get_all_jobs(exam_id)):
+    _id = UUID(exam_id) if not isinstance(exam_id, UUID) else exam_id
+    if not (jobs := await dal.get_all_jobs(_id)):
         # Don't raise exception, list might be empty
         return []
     return [await get_job_out(data=job) for job in jobs]
 
 
 @router.delete("/job/{job_id}", response_model={}, status_code=204, tags=["jobs"])
-async def job_delete(job_id: int) -> None:
+async def job_delete(job_id: UUID | str) -> None:
     """Delete job endpoint.
 
     Parameters
@@ -219,12 +226,13 @@ async def job_delete(job_id: int) -> None:
     HTTPException
         404: Not found
     """
-    if not await dal.delete_job(job_id):
+    _id = UUID(job_id) if not isinstance(job_id, UUID) else job_id
+    if not await dal.delete_job(_id):
         raise HTTPException(status_code=404, detail="Job not found")
 
 
 @router.put("/job/{job_id}", response_model=JobOut, status_code=200, tags=["jobs"])
-async def job_update(job_id: int, payload: BaseJob) -> JobOut:
+async def job_update(job_id: UUID | str, payload: BaseJob) -> JobOut:
     """Update job endpoint.
 
     Parameters
@@ -243,7 +251,8 @@ async def job_update(job_id: int, payload: BaseJob) -> JobOut:
     HTTPException
         404: Not found
     """
-    if not (job := await dal.update_job(job_id, payload)):
+    _id = UUID(job_id) if not isinstance(job_id, UUID) else job_id
+    if not (job := await dal.update_job(_id, payload)):
         raise HTTPException(status_code=404, detail="Job not found")
     return await get_job_out(data=job)
 
@@ -272,7 +281,7 @@ async def record_create(payload: RecordIn) -> RecordOut:
 
 
 @router.put("/record/{record_id}/", response_model=RecordOut, status_code=200, tags=["records"])
-async def update_record(record_id: int, payload: dict):
+async def update_record(record_id: UUID | str, payload: dict):
     """Update existing record.
 
     Parameters
@@ -291,14 +300,15 @@ async def update_record(record_id: int, payload: dict):
     HTTPException
         404: Not found
     """
-    record = await dal.update_record(record_id, payload)
+    _id = UUID(record_id) if not isinstance(record_id, UUID) else record_id
+    record = await dal.update_record(_id, payload)
     if not record:
         raise HTTPException(status_code=404, detail="Record not found")
     return await get_record_out(record)
 
 
 @router.get("/record/{record_id}", response_model=RecordOut, status_code=200, tags=["records"])
-async def record_get(record_id: int) -> RecordOut:
+async def record_get(record_id: UUID | str) -> RecordOut:
     """Get single record endpoint.
 
     Parameters
@@ -315,7 +325,8 @@ async def record_get(record_id: int) -> RecordOut:
     HTTPException
         404: Not found
     """
-    if not (record := await dal.get_record(record_id)):
+    _id = UUID(record_id) if not isinstance(record_id, UUID) else record_id
+    if not (record := await dal.get_record(_id)):
         raise HTTPException(status_code=404, detail="Record not found")
     return await get_record_out(data=record)
 
@@ -326,7 +337,7 @@ async def record_get(record_id: int) -> RecordOut:
     status_code=200,
     tags=["records"],
 )
-async def record_get_all(job_id: int) -> list[RecordOut]:
+async def record_get_all(job_id: UUID | str) -> list[RecordOut]:
     """Get all records of a job endpoint.
 
     Parameters
@@ -338,14 +349,15 @@ async def record_get_all(job_id: int) -> list[RecordOut]:
     -------
         List of record pydantic output model
     """
-    if not (records := await dal.get_all_records(job_id)):
+    _id = UUID(job_id) if not isinstance(job_id, UUID) else job_id
+    if not (records := await dal.get_all_records(_id)):
         # Don't raise exception here, list might be empty.
         return []
     return [await get_record_out(data=record) for record in records]
 
 
 @router.delete("/record/{record_id}", response_model={}, status_code=204, tags=["records"])
-async def record_delete(record_id: int) -> None:
+async def record_delete(record_id: UUID | str) -> None:
     """Delete record endpoint.
 
     Parameters
@@ -358,5 +370,6 @@ async def record_delete(record_id: int) -> None:
     HTTPException
         404: Not found
     """
-    if not await dal.delete_record(record_id):
+    _id = UUID(record_id) if not isinstance(record_id, UUID) else record_id
+    if not await dal.delete_record(_id):
         raise HTTPException(status_code=404, detail="Record not found")

--- a/services/exam-manager/app/api/exam.py
+++ b/services/exam-manager/app/api/exam.py
@@ -11,13 +11,10 @@ from .models import (
     BaseJob,
     ExamOut,
     JobOut,
-    ProcedureIn,
-    ProcedureOut,
     RecordIn,
     RecordOut,
     get_exam_out,
     get_job_out,
-    get_procedure_out,
     get_record_out,
 )
 
@@ -138,129 +135,6 @@ async def exam_update(exam_id: int, payload: BaseExam) -> ExamOut:
     return await get_exam_out(data=exam)
 
 
-@router.post("/procedure", response_model=ProcedureOut, status_code=201, tags=["procedures"])
-async def procedure_create(payload: ProcedureIn) -> ProcedureOut:
-    """Procedure post endpoint.
-
-    Parameters
-    ----------
-    payload
-        Pydantic input model
-
-    Returns
-    -------
-        Pydantic output model
-
-    Raises
-    ------
-    HTTPException
-        404: Creation not succesful
-    """
-    if not (procedure := await dal.procedure_add(payload)):
-        raise HTTPException(status_code=404, detail="Could not create procedure")
-    return await get_procedure_out(data=procedure)
-
-
-@router.get(
-    "/procedure/{procedure_id}",
-    response_model=ProcedureOut,
-    status_code=200,
-    tags=["procedures"],
-)
-async def procedure_get(procedure_id: int) -> ProcedureOut:
-    """Procedure get endpoint.
-
-    Parameters
-    ----------
-    procedure_id
-        Id of entry to return
-
-    Returns
-    -------
-        Pydantic output model
-
-    Raises
-    ------
-    HTTPException
-        404: Not found
-    """
-    if not (procedure := await dal.procedure_get(procedure_id)):
-        raise HTTPException(status_code=404, detail="Procedure not found")
-    return await get_procedure_out(data=procedure)
-
-
-@router.get(
-    "/procedure/all/{exam_id}",
-    response_model=list[ProcedureOut],
-    status_code=200,
-    tags=["procedures"],
-)
-async def procedure_get_all(exam_id: int) -> list[ProcedureOut]:
-    """Get all procedures of a parent endpoint.
-
-    Parameters
-    ----------
-    exam_id
-        Id of the parent object
-
-    Returns
-    -------
-        List of pydantic output models
-    """
-    if not (procedures := await dal.procedure_get_all(exam_id)):
-        # Don't raise exception, list might be empty
-        return []
-    return [await get_procedure_out(data=procedure) for procedure in procedures]
-
-
-@router.delete("/procedure/{procedure_id}", response_model={}, status_code=204, tags=["procedures"])
-async def procedure_delete(procedure_id: int) -> None:
-    """Delete procedure endpoint.
-
-    Parameters
-    ----------
-    procedure_id
-        Id of entry to be deleted
-
-    Raises
-    ------
-    HTTPException
-        404: Not found
-    """
-    if not await dal.procedure_delete(procedure_id):
-        raise HTTPException(status_code=404, detail="Procedure not found")
-
-
-@router.put(
-    "/procedure/{procedure_id}",
-    response_model=ProcedureOut,
-    status_code=200,
-    tags=["procedures"],
-)
-async def proceedure_update(procedure_id: int, payload: ProcedureIn) -> ProcedureOut:
-    """Update procedure endpoint.
-
-    Parameters
-    ----------
-    procedure_id
-        Id of procedure to be updated
-    payload
-        Pydantic input model
-
-    Returns
-    -------
-        Pydantic output model
-
-    Raises
-    ------
-    HTTPException
-        404: Entry not found
-    """
-    if not (procedure := await dal.procedure_update(procedure_id, payload)):
-        raise HTTPException(status_code=404, detail="Procedure not found")
-    return await get_procedure_out(data=procedure)
-
-
 @router.post("/job", response_model=JobOut, status_code=201, tags=["jobs"])
 async def job_create(payload: BaseJob) -> JobOut:
     """Create new job endpoint.
@@ -308,24 +182,24 @@ async def job_get(job_id: int) -> JobOut:
 
 
 @router.get(
-    "/job/all/{procedure_id}",
+    "/job/all/{exam_id}",
     response_model=list[JobOut],
     status_code=200,
     tags=["jobs"],
 )
-async def job_get_all(procedure_id: int) -> list[JobOut]:
-    """Get all jobs of a procedure endpoint.
+async def job_get_all(exam_id: int) -> list[JobOut]:
+    """Get all jobs of a exam endpoint.
 
     Parameters
     ----------
-    procedure_id
-        Id of parent procedure
+    exam_id
+        Id of parent exam
 
     Returns
     -------
         List of job pydantic output model
     """
-    if not (jobs := await dal.get_all_jobs(procedure_id)):
+    if not (jobs := await dal.get_all_jobs(exam_id)):
         # Don't raise exception, list might be empty
         return []
     return [await get_job_out(data=job) for job in jobs]

--- a/services/exam-manager/app/api/models.py
+++ b/services/exam-manager/app/api/models.py
@@ -3,6 +3,7 @@
 
 """Definitions of pydantic models and helper functions."""
 
+import uuid
 from datetime import datetime
 
 from pydantic import BaseModel, Extra
@@ -70,7 +71,7 @@ class BaseJob(BaseModel):
 
     type: str
     comment: str | None
-    exam_id: int
+    exam_id: uuid.UUID
     sequence_id: str
     workflow_id: int | None
     device_id: str
@@ -91,7 +92,7 @@ class BaseRecord(BaseModel):
 class RecordIn(BaseRecord):
     """Record input model."""
 
-    job_id: int
+    job_id: uuid.UUID
 
 
 class DeviceOut(BaseDevice):
@@ -113,14 +114,14 @@ class WorkflowOut(BaseWorkflow):
 class RecordOut(BaseRecord):
     """Record output model."""
 
-    id: int
+    id: uuid.UUID
     datetime_created: datetime
 
 
 class JobOut(BaseJob):
     """Job output model."""
 
-    id: int
+    id: uuid.UUID
     is_acquired: bool
     device: DeviceOut | None
     workflow: WorkflowOut | None
@@ -132,7 +133,7 @@ class JobOut(BaseJob):
 class ExamOut(BaseExam):
     """Exam output model."""
 
-    id: int
+    id: uuid.UUID
     datetime_created: datetime
     datetime_updated: datetime | None
     jobs: list[JobOut]

--- a/services/exam-manager/app/api/models.py
+++ b/services/exam-manager/app/api/models.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Extra
 
-from .db import Device, Exam, Job, Procedure, Record, Workflow
+from .db import Device, Exam, Job, Record, Workflow
 
 
 class BaseDevice(BaseModel):
@@ -60,18 +60,6 @@ class BaseExam(BaseModel):
     status: str
 
 
-class BaseProcedure(BaseModel):
-    """Procedure base model."""
-
-    class Config:
-        """Base class configuration."""
-
-        extra = Extra.ignore
-
-    name: str
-    status: str
-
-
 class BaseJob(BaseModel):
     """Job base model."""
 
@@ -82,7 +70,7 @@ class BaseJob(BaseModel):
 
     type: str
     comment: str | None
-    procedure_id: int
+    exam_id: int
     sequence_id: str
     workflow_id: int | None
     device_id: str
@@ -98,12 +86,6 @@ class BaseRecord(BaseModel):
 
     data_path: str | None
     comment: str | None
-
-
-class ProcedureIn(BaseProcedure):
-    """Procedure input model."""
-
-    exam_id: int
 
 
 class RecordIn(BaseRecord):
@@ -147,22 +129,13 @@ class JobOut(BaseJob):
     datetime_updated: datetime | None
 
 
-class ProcedureOut(BaseProcedure):
-    """Procedure output model."""
-
-    id: int
-    datetime_created: datetime
-    datetime_updated: datetime | None
-    jobs: list[JobOut]
-
-
 class ExamOut(BaseExam):
     """Exam output model."""
 
     id: int
     datetime_created: datetime
     datetime_updated: datetime | None
-    procedures: list[ProcedureOut]
+    jobs: list[JobOut]
 
 
 async def get_workflow_out(data: Workflow) -> WorkflowOut:
@@ -260,7 +233,7 @@ async def get_job_out(data: Job, device: Device = None, workflow: Workflow = Non
         type=data.type,
         comment=data.comment,
         is_acquired=data.is_acquired,
-        procedure_id=data.procedure_id,
+        exam_id=data.exam_id,
         sequence_id=data.sequence_id,
         device_id=data.device_id,
         workflow_id=data.workflow_id,
@@ -269,31 +242,6 @@ async def get_job_out(data: Job, device: Device = None, workflow: Workflow = Non
         records=records,
         datetime_created=data.datetime_created,
         datetime_updated=data.datetime_updated,
-    )
-
-
-async def get_procedure_out(data: Procedure) -> ProcedureOut:
-    """Procedure output helper function.
-
-    Parameters
-    ----------
-    data
-        Procedure database model
-
-    Returns
-    -------
-        Procedure pydantic output model
-    """
-    # Create jobs of the procedure
-    jobs = [await get_job_out(job) for job in data.jobs]
-
-    return ProcedureOut(
-        id=data.id,
-        name=data.name,
-        status=data.status,
-        datetime_created=data.datetime_created,
-        datetime_updated=data.datetime_updated,
-        jobs=jobs,
     )
 
 
@@ -310,7 +258,7 @@ async def get_exam_out(data: Exam) -> ExamOut:
         Exam pydantic output model
     """
     # Create procedures of the exam
-    exam_procedures = [await get_procedure_out(procedure) for procedure in data.procedures]
+    exam_jobs = [await get_job_out(job) for job in data.jobs]
 
     return ExamOut(
         id=data.id,
@@ -321,7 +269,7 @@ async def get_exam_out(data: Exam) -> ExamOut:
         address=data.address,
         creator=data.creator,
         status=data.status,
-        procedures=exam_procedures,
+        jobs=exam_jobs,
         datetime_created=data.datetime_created,
         datetime_updated=data.datetime_updated,
     )


### PR DESCRIPTION
This pull request removes the procedure model from the data hierarchy of the exam-manager.
According to the dicom standard, a study (exam) is assigned to a patient which may contain multiple series (records).
In ScanHub, a new record origins from the execution of a job. Thus the exam manager now manages exams, records and jobs.

Remove procedure:

- Data access layer (DAL)
- Pydantic models
- Database
- Endpoints


In addition the ID of exams, records and jobs is now implemented as UUID instead of int.

closes #85 
closes #78 