### PR TITLE
Hotfix exam microservice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - '*'
-  pull_request:
-    branches:
-      - '*'
 
 jobs:
   compose:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - docu
+  pull_request:
+    branches:
+      - main
 
 jobs:
   Documentation:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Each issue should have a detailed description including a description of the pro
 We appreciate it if the issue is updated with the actual solution approach during development.
 This documentation step might be helpful when working on similar or related issues.
 
-When you start working on an issue, please create a new branch which follows the naming convention `<ID>-short-name`.
+When you start working on an issue, please create a new branch according to the following naming convention.
+
+    Branch name: <ID>-short-name
+
 The `<ID>` refers to the ID of the related issue and `short-name` is a short expression for the title of the issue.
 Please link the branch to the issue, as soon as you start working on it.
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ Contributor Guide
 
 We appreciate every contribution to ScanHub, if you would like to contribute to the project, pleaase contact us.
 Based on a stable main-branch, we are implementing features based on issues.
+
 Feel free to open a new issues for any feature that you are missing in the current main branch.
 Each issue should have a detailed description including a description of the problem, bug or feature and a potential solution approach.
 We appreciate it if the issue is updated with the actual solution approach during development.
 This documentation step might be helpful when working on similar or related issues.
+
 When you start working on an issue, please create a new branch which follows the naming convention `<ID>-short-name`.
-`<ID>` refers to the ID of the related issue and `short-name` is a short expression for the title of the issue.
+The `<ID>` refers to the ID of the related issue and `short-name` is a short expression for the title of the issue.
 Please link the branch to the issue, as soon as you start working on it.
 
 About

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Documentation
 
 See our dedicated [Documentation](https://scanhub.brain-link.de/) web page to get insights into the structure of ScanHub, microservice APIs and more.
 
+Contributor Guide
+-----------
+
+We appreciate every contribution to ScanHub, if you would like to contribute to the project, pleaase contact us.
+Based on a stable main-branch, we are implementing features based on issues.
+Feel free to open a new issues for any feature that you are missing in the current main branch.
+Each issue should have a detailed description including a description of the problem, bug or feature and a potential solution approach.
+We appreciate it if the issue is updated with the actual solution approach during development.
+This documentation step might be helpful when working on similar or related issues.
+When you start working on an issue, please create a new branch which follows the naming convention `<ID>-short-name`.
+`<ID>` refers to the ID of the related issue and `short-name` is a short expression for the title of the issue.
+Please link the branch to the issue, as soon as you start working on it.
 
 About
 -----------

--- a/services/base/shared_libs/src/scanhub_libraries/models.py
+++ b/services/base/shared_libs/src/scanhub_libraries/models.py
@@ -201,31 +201,31 @@ class BaseTask(BaseModel):
         """Base class configuration."""
 
         # extra = Extra.ignore
-        schema_extra = {
-            "examples": [
-                {
-                    "description": "task description",
-                    "type": TaskType.PROCESSING_TASK,
-                    "args": {"arg1": "val1"},
-                    "artifacts": {
-                        "input": [
-                            {
-                                "path": "/data",
-                                "name": "inputfile2"
-                            }
-                        ],
-                        "output": [
-                            {
-                                "path": "/data",
-                                "name": "outputfile1"
-                            }
-                        ]
-                    },
-                    "task_destinations": [],
-                    "status": {TaskStatus.PENDING: "additional status information"}
-                }
-            ]
-        }
+        # schema_extra = {
+        #     "examples": [
+        #         {
+        #             "description": "task description",
+        #             "type": TaskType.PROCESSING_TASK,
+        #             "args": {"arg1": "val1"},
+        #             "artifacts": {
+        #                 "input": [
+        #                     {
+        #                         "path": "/data",
+        #                         "name": "inputfile2"
+        #                     }
+        #                 ],
+        #                 "output": [
+        #                     {
+        #                         "path": "/data",
+        #                         "name": "outputfile1"
+        #                     }
+        #                 ]
+        #             },
+        #             "task_destinations": [],
+        #             "status": {TaskStatus.PENDING: "additional status information"}
+        #         }
+        #     ]
+        # }
 
     workflow_id: Optional[UUID] = None  # Field("", description="ID of the workflow the task belongs to.")
     description: str

--- a/services/exam-manager/app/exam.py
+++ b/services/exam-manager/app/exam.py
@@ -331,7 +331,7 @@ async def get_all_exam_workflows(exam_id: UUID | str) -> list[WorkflowOut]:
 
 
 @router.get(
-    "/workflow/templates",
+    "/workflow/templates/all",
     response_model=list[WorkflowOut],
     status_code=200,
     tags=["workflows"],
@@ -511,7 +511,7 @@ async def get_all_workflow_tasks(workflow_id: UUID | str) -> list[TaskOut]:
     return result
 
 @router.get(
-    "/task/templates",
+    "/task/templates/all",
     response_model=list[TaskOut],
     status_code=200,
     tags=["tasks"],


### PR DESCRIPTION
Fixed a bug within the exam microservice regarding workflow and task get-endpoint paths.
If the endpoint path is just `"/task/templates"`, fast-api expects an ID, because the endpoint to get a task by ID is `"/task/templates/{task_id}"`.
This problem has been fixed for workflows and tasks using `"/workflow/templates/all"` for the get-all endpoints instead.