### PR TITLE
Fix contributor license agreement action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: 'https://github.com/brain-link/scanhub/blob/main/LICENSE'
           # branch should not be protected
           branch: 'main'
-          allowlist: dependabot
+          allowlist: schote,jobehrens,chdinh,dependabot
           remote-organization-name: brain-link
           remote-repository-name: 'licence-agreements'
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,17 +23,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
           # This token is required only if you have configured to store the signatures in a remote repository/organization
-          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
         with:
           path-to-signatures: '/cla/signatures.json'
           path-to-document: 'https://github.com/brain-link/scanhub/blob/main/LICENSE'
           # branch should not be protected
           branch: 'main'
-          allowlist: user1,bot*
+          allowlist: dependabot
+          remote-organization-name: brain-link
+          remote-repository-name: 'licence-agreements'
 
-         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
           #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
           #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'

--- a/cla/signatures.json
+++ b/cla/signatures.json
@@ -1,4 +1,0 @@
-{
-  "signedContributors": [
-  ]
-}


### PR DESCRIPTION
The contributor agreements are collected in a separate repository. The GitHub action reads and writes from it using a fine-grained access token.